### PR TITLE
Add type for port arguments

### DIFF
--- a/natpmp/__init__.py
+++ b/natpmp/__init__.py
@@ -178,7 +178,7 @@ class PortMapResponse(NATPMPResponse):
             version, opcode, result, sec_since_epoch, self.private_port,
             self.public_port, self.lifetime
         ) = struct.unpack('!BBHIHHI', bytes)
-        super(NATPMPResponse, self).__init__(
+        super(PortMapResponse, self).__init__(
             version, opcode, result, sec_since_epoch)
 
     def __str__(self):

--- a/natpmp/client.py
+++ b/natpmp/client.py
@@ -5,8 +5,8 @@ import natpmp
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('public_port')
-    parser.add_argument('private_port')
+    parser.add_argument('public_port', type=int)
+    parser.add_argument('private_port', type=int)
     parser.add_argument(
         '-u',
         '--udp',


### PR DESCRIPTION
There's an internal struct that requires the port values as integers but the port arguments are interpreted as strings. Not sure if this used to work, but it wasn't working in python3.8 before this fix.